### PR TITLE
angular-ui-bootstrap3 is gone, use angular-bootstrap instead

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "moment": "~2.4.0",
     "ngUpload": "~0.5.3",
     "angular-route": "~1.2.0",
-    "angular-ui-bootstrap3": "~0.6.0"
+    "angular-bootstrap": "~0.12.0"
   },
   "resolutions": {
     "angular": "~1.2.3"

--- a/nomenklatura/templates/app.html
+++ b/nomenklatura/templates/app.html
@@ -81,7 +81,7 @@
 
         "vendor/angular/angular.js",
         "vendor/angular-route/angular-route.js",
-        "vendor/angular-ui-bootstrap3/ui-bootstrap-tpls.js",
+        "vendor/angular-bootstrap/ui-bootstrap-tpls.js",
         "vendor/ngUpload/ng-upload.js",
 
         "js/app.js",


### PR DESCRIPTION
See #37 - angular-bootstrap looks and behaves like an drop-in-replacement :)