### PR TITLE
Create Entity needs (empty) attributes, else an HTTP 400 happens

### DIFF
--- a/nomenklatura/static/js/controllers/datasets.js
+++ b/nomenklatura/static/js/controllers/datasets.js
@@ -60,6 +60,7 @@ function DatasetsViewCtrl($scope, $routeParams, $location, $http, $modal, $timeo
 
     $scope.createEntity = function(form) {
         $scope.new_entity.dataset = $scope.dataset.name;
+        $scope.new_entity.attributes = {};
         var res = $http.post('/api/2/entities', $scope.new_entity);
         res.success(function(data) {
             $location.path('/entities/' + data.id);


### PR DESCRIPTION
```
{"status": 400, "errors": {"attributes": "Missing value"}, "name": "Invalid Data", "description": "attributes: Missing value"}
```

This is a simple fix.
I also tried to find out why [Entity.create](https://github.com/pudo/nomenklatura/blob/4d6bd262c966e18a698bb2b491abb5c3de58aeaa/nomenklatura/model/entity.py#L172) doesn't like nonexistent attributes, tracing it back to
[model/entity.py#L57](https://github.com/pudo/nomenklatura/blob/4d6bd262c966e18a698bb2b491abb5c3de58aeaa/nomenklatura/model/entity.py#L57). But I have no idea how to make `attributes` optional there, `if_missing/if_empty` don't seem to work there and the FormEncode documentation doesn't mention something else :(