### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -76,7 +76,7 @@ AliasStatement:
 
 ## Reading
 
-* https://dedupe.readthedocs.org/en/latest/
+* https://dedupe.readthedocs.io/en/latest/
 * https://github.com/OpenRefine/OpenRefine/wiki/Reconcilable-Data-Sources
 * https://github.com/OpenRefine/OpenRefine/wiki/Clustering-In-Depth
 * https://github.com/OpenRefine/OpenRefine/wiki/Reconciliation-Service-API


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
